### PR TITLE
Fix analysis history saving bug

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -44,7 +44,12 @@ export async function getAiAnalysis(
     
     // Save the analysis result to Firestore ONLY after a successful analysis and if it's not a follow-up question
     if (!question) {
-      await saveAnalysisResult(result, symbol, chartDataUri, userId);
+      try {
+        await saveAnalysisResult(result, symbol, chartDataUri, userId);
+      } catch (saveError) {
+        console.error('Failed to save analysis to history:', saveError);
+        // Don't fail the entire request if saving fails, just log the error
+      }
     }
     
     return { success: true, data: result };


### PR DESCRIPTION
Fix analyses not saving to history by replacing `serverTimestamp()` with `new Date()`.

The `serverTimestamp()` function was causing issues when used within a Next.js server action context, preventing analysis results from being saved to Firestore. Replacing it with `new Date()` resolves this saving problem. Additionally, error handling for the save operation has been improved, and the history retrieval logic now gracefully handles both `Date` objects and Firestore `Timestamp` objects.

---
<a href="https://cursor.com/background-agent?bcId=bc-3869146e-1b9b-459f-8b9c-21f3834cb7b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3869146e-1b9b-459f-8b9c-21f3834cb7b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

